### PR TITLE
CDPS-1620: Bring linting closer in line with HMPPS template

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,27 +1,5 @@
 import hmppsConfig from '@ministryofjustice/eslint-config-hmpps'
-import typescriptEslint from '@typescript-eslint/eslint-plugin'
 
-const defaultConfig = hmppsConfig({
+export default hmppsConfig({
   extraIgnorePaths: ['src/assets'],
 })
-
-defaultConfig.push({
-  plugins: {
-    '@typescript-eslint': typescriptEslint,
-  },
-  rules: {
-    'import/prefer-default-export': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-unused-vars': [
-      1,
-      {
-        argsIgnorePattern: 'res|next|^err|_',
-        ignoreRestSiblings: true,
-        caughtErrorsIgnorePattern: '^_',
-      },
-    ],
-    '@typescript-eslint/no-empty-object-type': [1, { allowInterfaces: 'always' }],
-  },
-})
-
-export default defaultConfig

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "security_audit": "npx audit-ci --config audit-ci.json",
     "prepare": "hmpps-precommit-hooks-prepare",
     "precommit:secrets": "gitleaks git --pre-commit --redact --staged --verbose --config .gitleaks/config.toml",
-    "precommit:lint": "node_modules/.bin/lint-staged",
+    "precommit:lint": "lint-staged",
     "precommit:verify": "npm run typecheck && npm test"
   },
   "lint-staged": {
@@ -47,7 +47,7 @@
     "url": "https://github.com/ministryofjustice/hmpps-connect-dps-shared-items-package/issues"
   },
   "devDependencies": {
-    "@ministryofjustice/eslint-config-hmpps": "^0.0.3",
+    "@ministryofjustice/eslint-config-hmpps": "^0.0.5",
     "@ministryofjustice/hmpps-precommit-hooks": "^0.0.3",
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-multi-entry": "^6.0.1",
@@ -56,9 +56,6 @@
     "@tsconfig/node22": "^22.0.2",
     "@types/jest": "^29.5.14",
     "@types/superagent": "^8.1.9",
-    "@typescript-eslint/eslint-plugin": "^8.41.0",
-    "eslint-import-resolver-typescript": "^4.4.4",
-    "eslint-plugin-no-only-tests": "^3.3.0",
     "govuk-frontend": "^5.11.2",
     "jest": "^29.7.0",
     "jest-html-reporter": "^3.10.2",

--- a/src/addressAutosuggest/osPlacesApiClient.ts
+++ b/src/addressAutosuggest/osPlacesApiClient.ts
@@ -33,7 +33,7 @@ export default class OsPlacesApiClient {
     try {
       const result = await superagent
         .get(endpoint)
-        .retry(2, (err, res) => {
+        .retry(2, (err, _res) => {
           if (err) this.logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
           return undefined // retry handler only for logging retries, not to influence retry logic
         })
@@ -41,8 +41,9 @@ export default class OsPlacesApiClient {
         .timeout(this.config.timeout)
 
       return result.body
-    } catch (error: any) {
-      throw Error(`Error calling OS Places API: ${error.message}`)
+    } catch (error) {
+      const errorMessage = error && typeof error === 'object' && 'message' in error ? error.message : error
+      throw Error(`Error calling OS Places API: ${errorMessage}`)
     }
   }
 }

--- a/src/addressAutosuggest/testMocks/osPlacesApiClientMock.ts
+++ b/src/addressAutosuggest/testMocks/osPlacesApiClientMock.ts
@@ -5,3 +5,5 @@ export const osPlacesApiClientMock = (): OsPlacesApiClient =>
     getAddressesByFreeTextQuery: jest.fn(),
     getAddressesByUprn: jest.fn(),
   }) as unknown as OsPlacesApiClient
+
+export default { osPlacesApiClientMock }

--- a/src/types/public/alertFlags/index.ts
+++ b/src/types/public/alertFlags/index.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
 export type { default as getAlertFlagLabelsForAlerts } from '../../../alertFlags/getAlertFlagLabelsForAlerts'


### PR DESCRIPTION
- removed eslint overrides to the shared HMPPS config – this is the cause of all changes to appease `eslint` and `tsc`
- tiny changes where an error had `any` type, but now it’s handled leniently
- no meaningful difference in built javascript