### PR TITLE
Downgrade main workflow’s default permissions to only read content

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run unit tests


### PR DESCRIPTION
Ref: https://github.com/ministryofjustice/hmpps-typescript-lib/pull/187